### PR TITLE
Updated to ES6

### DIFF
--- a/src/Data/Base58.js
+++ b/src/Data/Base58.js
@@ -1,14 +1,14 @@
 "use strict";
 
-var bs58 = require("bs58");
+import bs58 from "bs58";
 
 // module Data.Base58
 
-exports.encode = function(x) {
+export const encode = function(x) {
   return bs58.encode(x)
-}
+};
 
-exports.decodePrime = function(just, nothing, x) {
+export const decodePrime = function(just, nothing, x) {
   try {
     return just(bs58.decode(x));
   } catch (err) {


### PR DESCRIPTION
The new purescript compiler requires ES6 style of imports. This PR performs the migration.